### PR TITLE
Pin web3 dependencies to 1.2.5

### DIFF
--- a/packages/test-helpers/package.json
+++ b/packages/test-helpers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aragon/contract-helpers-test",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "author": "Aragon Assocation <legal@aragon.org>",
   "license": "MIT",
   "files": [
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "ethereumjs-abi": "^0.6.4",
-    "web3-eth-abi": "^1.2.1",
-    "web3-utils": "^1.2.1"
+    "web3-eth-abi": "1.2.5",
+    "web3-utils": "1.2.5"
   }
 }


### PR DESCRIPTION
With 1.2.8, decoding bytes data fields no longer works, errors like
this one appear:
```
     Error: data out-of-bounds (length=36, offset=64, code=BUFFER_OVERRUN, version=abi/5.0.0-beta.153)
      at Logger.makeError (node_modules/@ethersproject/logger/lib/index.js:178:21)
      at Logger.throwError (node_modules/@ethersproject/logger/lib/index.js:187:20)
      at Reader._peekBytes (node_modules/@ethersproject/abi/lib/coders/abstract-coder.js:135:20)
      at Reader.readBytes (node_modules/@ethersproject/abi/lib/coders/abstract-coder.js:146:26)
      at BytesCoder.DynamicBytesCoder.decode (node_modules/@ethersproject/abi/lib/coders/bytes.js:30:23)
      at BytesCoder.decode (node_modules/@ethersproject/abi/lib/coders/bytes.js:41:81)
      at node_modules/@ethersproject/abi/lib/coders/array.js:77:31
      at Array.forEach (<anonymous>)
      at Object.unpack (node_modules/@ethersproject/abi/lib/coders/array.js:71:12)
      at TupleCoder.decode (node_modules/@ethersproject/abi/lib/coders/tuple.js:39:49)
      at AbiCoder.decode (node_modules/@ethersproject/abi/lib/abi-coder.js:93:22)
      at ABICoder.decodeParameters (node_modules/web3-eth-abi/src/index.js:322:30)
      at ABICoder.decodeLog (node_modules/web3-eth-abi/src/index.js:376:52)
      at eventLogs.map.log (node_modules/@aragon/contract-helpers-test/events.js:18:20)
      at Array.map (<anonymous>)
      at decodeEvents (node_modules/@aragon/contract-helpers-test/events.js:16:20)
      at getDeepEventLogs (test/lock_and_call.js:9:10)
      at getDeepEventArgument (test/lock_and_call.js:12:16)
      at checkCallbackLog (test/lock_and_call.js:50:18)
      at Context.it (test/lock_and_call.js:59:7)
      at process._tickCallback (internal/process/next_tick.js:68:7)
```

You can see an example here:

https://github.com/aragon/staking/pull/21/commits/429e91d2c3b5330f666fe614a595cb5ffb01ac7e