### PR TITLE
Revert "Pin web3 dependencies to 1.2.5 (#32)"

### DIFF
--- a/packages/test-helpers/package.json
+++ b/packages/test-helpers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aragon/contract-helpers-test",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "author": "Aragon Assocation <legal@aragon.org>",
   "license": "MIT",
   "files": [
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "ethereumjs-abi": "^0.6.4",
-    "web3-eth-abi": "1.2.5",
-    "web3-utils": "1.2.5"
+    "web3-eth-abi": "^1.2.1",
+    "web3-utils": "^1.2.1"
   }
 }


### PR DESCRIPTION
This reverts commit 2cb94d67bf67bf0eb165451e802e8fae31434ce1.

It seems it was a false alarm. See https://github.com/ethereum/web3.js/issues/3544 for full context. Tested again locally with Staking repo npm-installing from scratch.