### PR TITLE
chore: remove lerna as none of the packages are interdependent

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,19 @@
 
 ## Structure
 
-This is a monorepo with a set of helpers to develop Aragon smart contracts.
+This is a monorepo containing utilities and helpers for developing smart contracts.
 
-Contains the following packages:
+Includes the following packages (see their packages for documentation):
 
-- **[Deploy Helpers](packages/deploy-helpers)**: Tools to deploy smart contracts on the Aragon framework
 - **[Test Helpers](packages/test-helpers)**: Smart contract test helpers for both generic Solidity and Aragon-related smart contracts
 - **[Truffle v5 config](packages/truffle-config-v5)**: Base Truffle v5 configuration for Aragon smart contract development
+
+The following packages have yet to be published:
+
+- **[Deploy Helpers](packages/deploy-helpers)**: Tools to deploy smart contracts on the Aragon framework
+
+## Developing
+
+Each individual package in the [`packages/`](./packages/) directory is a self-contained package that should be installed individually.
+
+As evidenced through the lock files, we generally use [`yarn`](https://yarnpkg.com/) during local development.

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,0 @@
-{
-  "packages": [
-    "packages/*"
-  ],
-  "version": "independent"
-}

--- a/package.json
+++ b/package.json
@@ -2,8 +2,5 @@
   "name": "@aragon/contract-helpers",
   "private": true,
   "author": "Aragon Assocation <legal@aragon.org>",
-  "license": "MIT",
-  "devDependencies": {
-    "lerna": "^3.16.4"
-  }
+  "license": "MIT"
 }


### PR DESCRIPTION
Lerna isn't very helpful in this case, as none of the packages are shared or interdependent between each other.

We can add it back when that becomes the case.