### PR TITLE
Test helpers: add chai to peer dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ This is a monorepo containing utilities and helpers for developing smart contrac
 
 Includes the following packages (see their packages for documentation):
 
-- **[Test Helpers](packages/test-helpers)**: Smart contract test helpers for both generic Solidity and Aragon-related smart contracts
-- **[Truffle v5 config](packages/truffle-config-v5)**: Base Truffle v5 configuration for Aragon smart contract development
+- **`@aragon/contract-helpers-test` ([Test helpers](packages/test-helpers))**: Test helpers for both generic Solidity and Aragon-related smart contracts
+- **`@aragon/truffle-config-v5` ([Truffle v5 config](packages/truffle-config-v5))**: Base Truffle v5 configuration for Aragon smart contract development
 
 The following packages have yet to be published:
 

--- a/packages/test-helpers/assertBn.js
+++ b/packages/test-helpers/assertBn.js
@@ -1,3 +1,5 @@
+const { assert } = require('chai')
+
 const assertBn = (actual, expected, errorMsg) => {
   assert.equal(actual.toString(), expected.toString(), `${errorMsg} expected ${expected.toString()} to equal ${actual.toString()}`)
 }

--- a/packages/test-helpers/assertEvent.js
+++ b/packages/test-helpers/assertEvent.js
@@ -1,5 +1,7 @@
-const { getEventAt, getEvents } = require('./events')
+const { assert } = require('chai')
 const { isAddress, isBN, toChecksumAddress } = require('web3-utils')
+
+const { getEventAt, getEvents } = require('./events')
 
 function assertEvent(receipt, eventName, expectedArgs = {}, index = 0) {
   const event = getEventAt(receipt, eventName, index)

--- a/packages/test-helpers/assertRole.js
+++ b/packages/test-helpers/assertRole.js
@@ -1,3 +1,5 @@
+const { assert } = require('chai')
+
 const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000'
 
 module.exports = web3 => {

--- a/packages/test-helpers/assertThrow.js
+++ b/packages/test-helpers/assertThrow.js
@@ -1,3 +1,5 @@
+const { assert } = require('chai')
+
 const THROW_ERROR_PREFIX = 'Returned error: VM Exception while processing transaction: revert'
 
 async function assertThrows(blockOrPromise, expectedErrorCode, expectedReason) {

--- a/packages/test-helpers/package.json
+++ b/packages/test-helpers/package.json
@@ -9,6 +9,7 @@
     "/contracts"
   ],
   "peerDependencies": {
+    "chai": "^4.2.0",
     "ganache-cli": "^6.0.0",
     "solidity-coverage": "^0.6.2"
   },


### PR DESCRIPTION
To be a bit more safe, add `chai` as a peer dependency and import it directly on assertions.

Truffle automagically injects `chai` into the global environment, so this adds a bit of "feature proofing" if used outside of that environment.

Note that these test helpers are still generally coupled to `truffle-contract`, as its events object differs from `web3`'s (e.g. see [this conversion](https://github.com/OpenZeppelin/openzeppelin-test-helpers/blob/master/src/expectEvent.js#L18)).