### PR TITLE
test-helpers: add ability to transparently decode raw events in event utilities

### DIFF
--- a/packages/test-helpers/src/asserts/assertEvent.js
+++ b/packages/test-helpers/src/asserts/assertEvent.js
@@ -16,8 +16,12 @@ function normalizeArg(arg) {
   return arg
 }
 
-function assertEvent(receipt, eventName, expectedArgs = {}, index = 0) {
-  const event = getEventAt(receipt, eventName, index)
+function assertEvent(
+  receipt,
+  eventName,
+  { index = 0, expectedArgs = {}, ...options } = {}
+) {
+  const event = getEventAt(receipt, eventName, { index, ...options })
 
   assert(
     typeof event === 'object',
@@ -38,8 +42,12 @@ function assertEvent(receipt, eventName, expectedArgs = {}, index = 0) {
   }
 }
 
-function assertAmountOfEvents(receipt, eventName, expectedAmount = 1) {
-  const events = getEvents(receipt, eventName)
+function assertAmountOfEvents(
+  receipt,
+  eventName,
+  { expectedAmount = 1, ...options } = {}
+) {
+  const events = getEvents(receipt, eventName, options)
   assert.equal(
     events.length,
     expectedAmount,

--- a/packages/test-helpers/src/events.js
+++ b/packages/test-helpers/src/events.js
@@ -1,13 +1,19 @@
-function getEvents({ logs = [] }, eventName) {
+const { decodeEvents } = require('./')
+
+function getEvents(receipt, eventName, { decodeForAbi } = {}) {
+  const logs = decodeForAbi
+    ? decodeEvents(receipt, decodeForAbi, eventName)
+    : receipt.logs
+
   return logs.filter((l) => l.event === eventName)
 }
 
-function getEventAt(receipt, eventName, index = 0) {
-  return getEvents(receipt, eventName)[index]
+function getEventAt(receipt, eventName, { index = 0, ...options } = {}) {
+  return getEvents(receipt, eventName, options)[index]
 }
 
-function getEventArgument(receipt, eventName, arg, index = 0) {
-  return getEventAt(receipt, eventName, index).args[arg]
+function getEventArgument(receipt, eventName, arg, options) {
+  return getEventAt(receipt, eventName, options).args[arg]
 }
 
 module.exports = {


### PR DESCRIPTION
Fixes https://github.com/aragon/aragon-apps/issues/1211.

Updates the event utilities and assertions to now take an optional trailing `options` argument, rather than just specifying the `index`.

This allows users to include a `decodeForAbi` option that will force the event utility into decoding the raw logs for that abi and event name.

Example:

```js
const Voting = artifacts.require('Voting')
assertEvent(receipt, 'NewVote', { index: 2, decodeForAbi: Voting.abi })
```