### PR TITLE
test-helpers: Flesh out empty bytes

### DIFF
--- a/packages/test-helpers/src/bytes.js
+++ b/packages/test-helpers/src/bytes.js
@@ -1,4 +1,4 @@
-const EMPTY_BYTES = '0x00'
+const EMPTY_BYTES = '0x00' // Empty bytes from Solidity getters are returned with 2 zeroes
 const ZERO_BYTES32 = '0x' + '0'.repeat(64) // 0x0000...0000
 
 function stripBytePrefix(bytes) {

--- a/packages/test-helpers/src/bytes.js
+++ b/packages/test-helpers/src/bytes.js
@@ -1,4 +1,4 @@
-const EMPTY_BYTES = '0x'
+const EMPTY_BYTES = '0x00'
 const ZERO_BYTES32 = '0x' + '0'.repeat(64) // 0x0000...0000
 
 function stripBytePrefix(bytes) {


### PR DESCRIPTION
Empty bytes from Solidity getters are returned with 2 zeroes, so it’s
better to have them this way to compare.