### PR TITLE
test-helpers: remove @aragon/os from optional dependencies

### DIFF
--- a/packages/test-helpers/package.json
+++ b/packages/test-helpers/package.json
@@ -12,9 +12,6 @@
     "/src"
   ],
   "main": "src/index.js",
-  "optionalDependencies": {
-    "@aragon/os": "^4.0.0"
-  },
   "peerDependencies": {
     "chai": "^4.2.0",
     "web3": "^1.0.0"


### PR DESCRIPTION
This was a cute attempt but `npm` still installs dependencies marked as optional by default (you need to pass flags and etc. to skip it).

While `@aragon/os@5` won't be as big as it is now, it is still awkward to default to an install when just using the generic utilities.

Given that contracts and etc. won't compile if this isn't available, and that if you're using aragonOS-related utilities you are most definitely working with those contracts in your artifact system, the lack of this in the package.json should not be a big problem.