### PR TITLE
Update assertRevert to support buidler dev tool

### DIFF
--- a/packages/test-helpers/src/asserts/assertThrow.js
+++ b/packages/test-helpers/src/asserts/assertThrow.js
@@ -2,8 +2,8 @@ const { assert } = require('chai')
 const { isGeth } = require('../node')
 const { decodeErrorReasonFromTx } = require('../decoding')
 
-const THROW_ERROR_PREFIX =
-  'Returned error: VM Exception while processing transaction: revert'
+const ERROR_PREFIX = 'Returned error:'
+const THROW_PREFIX = 'VM Exception while processing transaction: revert'
 
 async function assertThrows(
   blockOrPromise,
@@ -83,10 +83,14 @@ async function assertRevert(blockOrPromise, expectedReason, ctx) {
     return
   }
 
-  // Truffle v5 provides `error.reason`, but v4 does not.
-  if (!error.reason && error.message.includes(THROW_ERROR_PREFIX)) {
-    error.reason = error.message.replace(THROW_ERROR_PREFIX, '').trim()
+  // Truffle v5 provides `error.reason`, but v4 and buidler does not.
+  if (!error.reason && error.message.includes(THROW_PREFIX)) {
+    error.reason = error.message
+      .replace(ERROR_PREFIX, '')
+      .replace(THROW_PREFIX, '')
+      .trim()
   }
+
   // Truffle 5 sometimes adds an extra ' -- Reason given: reason.' to the error message 🤷
   error.reason = error.reason
     .replace(` -- Reason given: ${expectedReason}.`, '')


### PR DESCRIPTION
Note that the current test setup is not using the `buidlerevm` yet because a few tests broke when we assert with our own `assertRevert` helper as explained here: https://github.com/aragon/contract-helpers/pull/53#discussion_r467152817.