### PR TITLE
test-helpers: allow decodeEvents to transparently consume `getTransactionReceipt()` receipts

### DIFF
--- a/packages/test-helpers/src/asserts/assertThrow.js
+++ b/packages/test-helpers/src/asserts/assertThrow.js
@@ -91,7 +91,7 @@ async function assertRevert(blockOrPromise, expectedReason, ctx) {
       .trim()
   }
 
-  // Truffle 5 sometimes adds an extra ' -- Reason given: reason.' to the error message 🤷
+  // Truffle v5 sometimes adds an extra ' -- Reason given: reason.' to the error message 🤷
   error.reason = error.reason
     .replace(` -- Reason given: ${expectedReason}.`, '')
     .trim()

--- a/packages/test-helpers/src/decoding.js
+++ b/packages/test-helpers/src/decoding.js
@@ -41,7 +41,13 @@ async function decodeErrorReasonFromTx(tx, ctx) {
 
 function decodeEvents(receipt, contractAbi, eventName) {
   const rawLogs =
-    receipt.rawLogs || (receipt.receipt && receipt.receipt.rawLogs) || []
+    // Raw logs from a truffle-contract receipt
+    receipt.rawLogs ||
+    // Potentially nested truffle-contract receipt
+    (receipt.receipt && receipt.receipt.rawLogs) ||
+    // web3.eth.getTransactionReceipt() returns the raw logs as just `receipt.logs`
+    receipt.logs ||
+    []
 
   const eventAbi = contractAbi.filter(
     (abi) => abi.name === eventName && abi.type === 'event'


### PR DESCRIPTION
This was a bit of a pain here: https://github.com/aragon/aragon-network-token/blob/master/packages/controller/test/ANTController.js#L56